### PR TITLE
Remove Amazon ads and add URL parse and display functionality

### DIFF
--- a/src/app/routes/home/home.component.html
+++ b/src/app/routes/home/home.component.html
@@ -16,9 +16,5 @@
     {{creatingRoom ? 'Creating...' : 'Create'}}
   </button>
 
-  <div style="margin-top: 16px">
-    <iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=288&l=ur1&category=kindle&banner=13EYZB9B1T115PQCXP82&f=ifr&linkID=f9c9c02d4c0676d10e4b08ce91e21f85&t=levibarkersto-20&tracking_id=levibarkersto-20" width="320" height="50" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0" sandbox="allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation"></iframe>
-  </div>
-
 </div>
 

--- a/src/app/routes/room/room.component.html
+++ b/src/app/routes/room/room.component.html
@@ -11,8 +11,13 @@
         <mat-form-field style="width: 100%" appearance="outline" class="example-full-width">
           <mat-label>Issue</mat-label>
           <input matInput [(ngModel)]="issue" (keydown.enter)="updateIssue(issue)" (blur)="updateIssue(issue)">
+          <mat-hint *ngIf="isUrl(issue)" style="font-size: 12px">
+            <span>Ticket link:&nbsp;</span>
+            <a [href]="issue" target="_blank">{{getLastPartOfUrlPath(issue)}}</a>
+          </mat-hint>
         </mat-form-field>
-        <div style="display: flex; gap: 8px; align-items: center;">
+
+        <div style="padding-top: 8px; display: flex; gap: 8px; align-items: center;">
           <button mat-stroked-button color="primary" (click)="toggleShowCards(room)">{{room.show_cards ? 'Hide' : 'Show'}} Votes</button>
           <button mat-stroked-button color="warn" (click)="clearVotes(room)">Clear Votes</button>
           <div>Average: {{room.show_cards ? average : '???'}}</div>

--- a/src/app/routes/room/room.component.ts
+++ b/src/app/routes/room/room.component.ts
@@ -197,4 +197,21 @@ export class RoomComponent {
       duration: 2000,
     });
   }
+
+  getLastPartOfUrlPath(url: String) {
+    var urlParts = url.split("/");
+    return urlParts[urlParts.length - 1];
+  }
+
+  isUrl(input: string) {
+    var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
+      '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+      '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+      '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
+    return pattern.test(input);
+  }
 }
+
+


### PR DESCRIPTION
Removed unnecessary Amazon banner ads from the home page. Added functionality in the 'room' component to parse and identify URLs and display the last part of the URL path. This allows for clearer and concise ticket links that can open in a separate tab.